### PR TITLE
Authentication Improvement

### DIFF
--- a/backend/src/main/java/com/synbiohub/sbh3/controllers/AdminController.java
+++ b/backend/src/main/java/com/synbiohub/sbh3/controllers/AdminController.java
@@ -7,7 +7,9 @@ import com.synbiohub.sbh3.services.UserService;
 import com.synbiohub.sbh3.utils.ConfigUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
@@ -20,13 +22,12 @@ public class AdminController {
     private final AdminService adminService;
     private final UserService userService;
     private final SearchService searchService;
-
-
     @GetMapping(value = "/admin/sparql")
     @ResponseBody
     public String runAdminSparqlQuery(@RequestParam String query, HttpServletRequest request) throws Exception {
         String inputToken = request.getHeader("X-authorization");
-        Authentication auth = userService.checkAuthentication(inputToken);
+//        Authentication auth = userService.checkAuthentication(inputToken);
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null) {
             return null;
         }

--- a/backend/src/main/java/com/synbiohub/sbh3/security/CustomUserDetails.java
+++ b/backend/src/main/java/com/synbiohub/sbh3/security/CustomUserDetails.java
@@ -1,6 +1,5 @@
 package com.synbiohub.sbh3.security;
 
-import com.synbiohub.sbh3.security.model.User;
 import lombok.Builder;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -8,6 +7,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Builder
 public class CustomUserDetails implements UserDetails {
@@ -19,10 +19,14 @@ public class CustomUserDetails implements UserDetails {
     private Boolean accountNonLocked;
     private Boolean credentialsNonExpired;
     private Boolean enabled;
+    private Collection<String> roles;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return this.authorities;
+        // Convert roles to authorities
+        return roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/backend/src/main/java/com/synbiohub/sbh3/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/synbiohub/sbh3/security/config/SecurityConfig.java
@@ -48,21 +48,16 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final AuthenticationProvider authenticationProvider;
 
+    //TODO: ADD isOwnedBy method
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests()
-                .requestMatchers("/**").permitAll()
+                .requestMatchers("/setup", "/login", "/register", "/search", "/search/**", "/searchCount", "/searchCount/**", "/twins", "/uses", "/similar", "/sbol", "/sbolnr", "/metadata", "/gb", "/fasta", "/gff", "/download", "/public/**", "/sparql", "/ComponentDefinition/**", "/**/count", "/count").permitAll()
+                .anyRequest().authenticated()
                 .and()
-                .authorizeHttpRequests((auth) -> auth.anyRequest().authenticated())
-                .csrf((csrf) -> csrf.disable())
+                .csrf().disable()
                 .httpBasic(Customizer.withDefaults())
-//                .logout()
-//                    .logoutUrl("/do_logout")
-//                    .logoutRequestMatcher(new AntPathRequestMatcher("/do_logout", "POST"))
-//                    .invalidateHttpSession(true)
-//                    .deleteCookies("JSESSIONID")
-//                .and()
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()

--- a/backend/src/main/java/com/synbiohub/sbh3/security/customsecurity/EndpointProperties.java
+++ b/backend/src/main/java/com/synbiohub/sbh3/security/customsecurity/EndpointProperties.java
@@ -1,0 +1,23 @@
+package com.synbiohub.sbh3.security.customsecurity;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Map;
+
+@Configuration
+@ConfigurationProperties
+public class EndpointProperties {
+    private Map<String, List<String>> roleToEndpointPermissions;
+
+    public List<String> getRoleToEndpointPermissions(String role) {
+        return roleToEndpointPermissions.get(role);
+    }
+
+    public void setRoleToEndpointPermissions(Map<String, List<String>> roleToEndpointPermissions) {
+        this.roleToEndpointPermissions = roleToEndpointPermissions;
+    }
+}
+
+

--- a/backend/src/main/java/com/synbiohub/sbh3/security/customsecurity/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/synbiohub/sbh3/security/customsecurity/JwtAuthenticationFilter.java
@@ -1,20 +1,27 @@
 package com.synbiohub.sbh3.security.customsecurity;
 
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.print.DocFlavor;
 import java.io.IOException;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Component
 @RequiredArgsConstructor
@@ -23,6 +30,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtService jwtService;
 
     private final UserDetailsService userDetailsService;
+
+    @Autowired
+    private EndpointProperties endpointProperties;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -39,6 +49,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         jwt = authHeader == null ? xauthHeader : authHeader;
         username = jwtService.extractUsername(jwt);
+        var claim = jwtService.extractAllClaims(jwt);
+        List<String> userRoles = convertAuthoritiesToRoles(claim);
+
         if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
             UserDetails userDetails = this.userDetailsService.loadUserByUsername(username);
             if (jwtService.isTokenValid(jwt, userDetails)) {
@@ -49,7 +62,38 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(authToken);
             }
         }
+
+        Set<String> allowedEndpoints = new HashSet<>(endpointProperties.getRoleToEndpointPermissions("USER"));
+        String requestedEndpoint = request.getRequestURI();
+        for (String role : userRoles) {
+            allowedEndpoints.addAll(endpointProperties.getRoleToEndpointPermissions(role));
+        }
+        boolean isEndpointAllowed = false;
+        AntPathMatcher pathMatcher = new AntPathMatcher();
+        for (String allowedEndpoint : allowedEndpoints) {
+            if (pathMatcher.match(allowedEndpoint, requestedEndpoint)) {
+                isEndpointAllowed = true;
+                break;
+            }
+        }
+
+        if (!isEndpointAllowed) {
+            // User's role does not have the correct permission for the requested endpoint.
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "You don't have the permission to access this resource.");
+            return;
+        }
         filterChain.doFilter(request, response);
 
+    }
+
+    private List<String> convertAuthoritiesToRoles(Claims claim) {
+        List<LinkedHashMap<String, String>> userAuthorities = (List<LinkedHashMap<String, String>>) claim.get("Role");
+
+        List<String> userRoles = new ArrayList<>();
+        for (LinkedHashMap<String, String> authority : userAuthorities) {
+            String role = authority.values().iterator().next();
+            userRoles.add(role);
+        }
+        return userRoles;
     }
 }

--- a/backend/src/main/java/com/synbiohub/sbh3/security/customsecurity/JwtService.java
+++ b/backend/src/main/java/com/synbiohub/sbh3/security/customsecurity/JwtService.java
@@ -33,6 +33,7 @@ public class JwtService {
     }
 
     public String generateToken(Map<String, Object> extraClaims, UserDetails userDetails) {
+        extraClaims.put("Role", userDetails.getAuthorities());
         return Jwts
                 .builder()
                 .setClaims(extraClaims)
@@ -56,7 +57,7 @@ public class JwtService {
         return extractClaim(token, Claims::getExpiration);
     }
 
-    private Claims extractAllClaims(String token) {
+    public Claims extractAllClaims(String token) {
         return Jwts
                 .parserBuilder()
                 .setSigningKey(getSigningKey())

--- a/backend/src/main/java/com/synbiohub/sbh3/services/AdminService.java
+++ b/backend/src/main/java/com/synbiohub/sbh3/services/AdminService.java
@@ -7,6 +7,7 @@ import com.synbiohub.sbh3.utils.ConfigUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -20,8 +21,9 @@ public class AdminService {
 
     public JsonNode getStatus(HttpServletRequest request) throws Exception {
         String inputToken = request.getHeader("X-authorization");
-        Authentication authentication = userService.checkAuthentication(inputToken);
-        if (authentication == null) {
+//        Authentication authentication = userService.checkAuthentication(inputToken);
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null) {
             return null;
         }
         ObjectNode status = mapper.createObjectNode();

--- a/backend/src/main/java/com/synbiohub/sbh3/services/UserService.java
+++ b/backend/src/main/java/com/synbiohub/sbh3/services/UserService.java
@@ -73,13 +73,13 @@ public class UserService {
 
     public String logoutUser(HttpServletRequest request) throws Exception {
         String token = request.getHeader("X-authorization");
-        Authentication auth = checkAuthentication(token);
+//        Authentication auth = checkAuthentication(token);
         // TODO: to get the authentication, we need the inputToken, which means that logout requires the token as a parameter
         // Check with Chris if this is the way to go
         HttpSession session = request.getSession();
         if (session != null && session.getId() != null) {
             session.invalidate();
-            authRepository.delete(authRepository.findByName(auth.getName()).orElseThrow());
+            authRepository.delete(authRepository.findByName(token).orElseThrow());
         }
         return "User logged out successfully";
     }
@@ -107,10 +107,13 @@ public class UserService {
     /**
      * This is the main method to check one's authentication.
      * It will check both the security context and the authTokens table to verify the user is logged in.
+     *
+     * Currently not used. Eventually will be deprecated out and deleted.
      * @param inputToken
      * @return
      * @throws Exception
      */
+    //TODO: either delete this or put inside filter when filter is done
     public Authentication checkAuthentication(String inputToken) throws Exception {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication instanceof AnonymousAuthenticationToken || authentication == null) return null;
@@ -176,18 +179,20 @@ public class UserService {
     }
 
     public User getUserProfile(String inputToken) throws Exception {
-        Authentication authentication = checkAuthentication(inputToken);
-        if (authentication == null) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+//        Authentication authentication = checkAuthentication(inputToken);
+        if (auth == null) {
             return null;
         }
-        User user = userRepository.findByUsername(authentication.getName()).orElseThrow();
+        User user = userRepository.findByUsername(auth.getName()).orElseThrow();
         User copyUser = (User) user.clone();
         copyUser.setPassword("");
         return copyUser;
     }
 
     public User updateUserProfile(Map<String, String> allParams, String inputToken) throws Exception {
-        Authentication auth = checkAuthentication(inputToken);
+//        Authentication auth = checkAuthentication(inputToken);
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         User existingUser = getUserProfile(inputToken);
         if (existingUser == null || auth == null) {
             return null;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -37,3 +37,27 @@ plugin:
 jwt:
   private.key: classpath:app.priv
   public.key: classpath:app.pub
+
+roleToEndpointPermissions:
+  USER: ["/profile", "/do_logout", "/submit", "/makePublic", "/rootCollections", "/setup", "/login", "/register", "/search", "/search/**", "/searchCount", "/searchCount/**", "/twins", "/uses", "/similar", "/sbol", "/sbolnr", "/metadata", "/gb", "/fasta", "/gff", "/download", "/public/**", "/sparql", "/ComponentDefinition/**", "/**/count", "/count"]
+  CURATOR: []
+  ADMIN: ['/admin/sparql', '/admin', '/admin/virtuoso', '/admin/graphs', '/admin/log', '/admin/mail', '/admin/plugins', '/admin/savePlugin', '/admin/deletePlugin', '/admin/registries', '/admin/saveRegistry', '/admin/deleteRegistry', '/admin/setAdministratorEmail', '/admin/retrieveFromWebOfRegistries', '/admin/federate', '/admin/remotes', '/admin/saveRemote', '/admin/deleteRemote', '/admin/explorerlog', '/admin/explorer', '/admin/explorerUpdateIndex', '/admin/theme', '/admin/users', '/admin/newUser', '/admin/updateUser', '/admin/deleteUser']
+
+#  login: /login
+#  logout: /do_logout
+#  register: /register
+#  resetPassword: /resetPassword
+#  setNewPassword: /setNewPassword
+#  profile: /profile
+#  search: /search/**
+#  searchCount: /searchCount/**
+#  rootCollections: /rootCollections
+#  submissions: /manage
+#  shared: /shared
+#  subCollections: /subCollections
+#  twins: /twins
+#  similar: /similar
+#  uses: /uses
+#  sbol: /sbol
+#  sbolnr: /sbolnr
+#  metadata: /metadata


### PR DESCRIPTION
TLDR: moved authentication check before the endpoint to the security filter

Commented out authentication check function
Added endpoint properties to new class and .yml file. Added endpoint permission check to jwt authentication filter Changed the way Roles and Authorities are stored and accessed for all users Admin endpoints have correct permissions now
Normal user endpoints are double booked, and may need better logic to organize them, particularly when users are logged in and accessing public endpoints. More specifically, when logged in, the filter always checks to see if the request endpoint is a "USER" required endpoint, even if the endpoint doesn't require authentication.