### PR TITLE
affiliation fix

### DIFF
--- a/backend/src/main/java/com/synbiohub/sbh3/security/model/User.java
+++ b/backend/src/main/java/com/synbiohub/sbh3/security/model/User.java
@@ -38,7 +38,7 @@ public class User implements UserDetails, Cloneable{
     private String email;
 
     @Column(name = "affiliation")
-    private String affiliation;
+    private String affiliation = "";
 
     @Enumerated(EnumType.STRING)
     @Column(name = "user_role")


### PR DESCRIPTION
Affiliation should be an empty string if no affiliation is specified instead of a null