### PR TITLE
Fix infinite page load on setup page

### DIFF
--- a/frontend/specialAccess/setup.js
+++ b/frontend/specialAccess/setup.js
@@ -56,10 +56,6 @@ export default function Setup({ setInSetupMode }) {
     setSecondaryTitleStyle({ color: reduceBrightness(color, 0.25) });
   }, [color]);
 
-  // useEffect(() => {
-  //   router.push('/setup');
-  // }, [router]);
-
   return (
     <TopLevel doNotTrack={true} navbar={<div></div>} publicPage={true}>
       <div className={styles.container}>

--- a/frontend/specialAccess/setup.js
+++ b/frontend/specialAccess/setup.js
@@ -56,9 +56,9 @@ export default function Setup({ setInSetupMode }) {
     setSecondaryTitleStyle({ color: reduceBrightness(color, 0.25) });
   }, [color]);
 
-  useEffect(() => {
-    router.push('/setup');
-  }, [router]);
+  // useEffect(() => {
+  //   router.push('/setup');
+  // }, [router]);
 
   return (
     <TopLevel doNotTrack={true} navbar={<div></div>} publicPage={true}>


### PR DESCRIPTION
Removing the router push effect prevents the infinite loading issue on the setup page.