### PR TITLE
Private Share Link Capability Fixed

### DIFF
--- a/frontend/components/Viewing/Modals/DownloadModal.js
+++ b/frontend/components/Viewing/Modals/DownloadModal.js
@@ -40,7 +40,7 @@ export default function DownloadModal(properties) {
    * 
    * @param {String} type The download endpoint the user has chosen.
    */
-  const download = (type, pluginName) => {
+  const download = async (type, pluginName) => {
     
     if (type != 'plugin') {
     const item = {
@@ -62,12 +62,28 @@ export default function DownloadModal(properties) {
       status: "downloading"
     };
 
+    let uri = properties.uri;
+
+    if(!uri.includes('/public/')) {
+      const shareLink = await getShareLink(uri.split(theme.uriPrefix).join(''));
+      uri = shareLink;
+      //Replace backend with uriPrefix
+      uri = uri.replace(publicRuntimeConfig.backend, theme.uriPrefix);
+    }
+
+    let uriSuffix = uri.split(theme.uriPrefix).join('');
+    //Remove first slash if it exists
+    if (uriSuffix.startsWith('/')) {
+      uriSuffix = uriSuffix.slice(1);
+    }
+
     
     const pluginData = {
-      uriSuffix: properties.uri.split(theme.uriPrefix).join(''),
+      uriSuffix: uriSuffix,
       instanceUrl: `${publicRuntimeConfig.backend}/`,
       size: 1,
-      type: properties.type
+      type: properties.type,
+      top: properties.uri
     };
     
 
@@ -212,4 +228,23 @@ export default function DownloadModal(properties) {
       }
     />
   );
+}
+
+
+async function getShareLink(uriSuffix) {
+  const token = localStorage.getItem('userToken');
+  return await axios({
+    method: 'GET',
+    url: `${publicRuntimeConfig.backend}/${uriSuffix}/shareLink`,
+    user: token, // Assuming the API requires a user token for authentication
+    headers: {
+      'Accept': 'text/plain',
+      'X-authorization': token
+    }
+  }).then(response => {
+    return response.data;
+  }
+  ).catch(error => {
+    return error;
+  });
 }

--- a/frontend/components/Viewing/Plugin.js
+++ b/frontend/components/Viewing/Plugin.js
@@ -25,7 +25,7 @@ export default function Plugin(properties) {
 
   const acceptedTags = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'a', 'img', 'ul', 'ol', 'li', 'table', 'tr', 'td', 'th', 'thead', 'tbody', 'tfoot', 'caption', 'div', 'span', 'br', 'hr', 'pre', 'code', 'blockquote', 'strong', 'em', 'i', 'b', 'u', 's', 'sub', 'sup', 'del', 'ins', 'mark', 'small', 'big', 'abbr', 'cite', 'dfn', 'kbd', 'q', 'samp', 'var', 'time', 'address', 'article', 'aside', 'footer', 'header', 'nav', 'section', 'main', 'figure', 'figcaption', 'details', 'summary', 'dialog', 'menu', 'menuitem', 'menuitem', 'meter', 'progress', 'output', 'canvas', 'audio', 'video', 'iframe', 'object', 'embed', 'param', 'source', 'track', 'map', 'area', 'form', 'label', 'input', 'button', 'select', 'datalist', 'optgroup', 'option', 'textarea', 'fieldset', 'legend', 'datalist', 'output', 'progress', 'meter', 'details', 'summary', 'command', 'menu', 'menuitem', 'menuitem', 'script', 'noscript', 'style', 'link', 'meta', 'title', 'base', 'head', 'body', 'html', 'br', 'hr', 'wbr', 'img', 'area', 'map', 'track', 'source', 'param', 'iframe', 'embed', 'object', 'canvas', 'script', 'noscript', 'style', 'link', 'meta', 'title', 'base', 'head', 'body', 'html', 'br', 'hr', 'wbr', 'img', 'area', 'map', 'track', 'source', 'param', 'iframe', 'embed', 'object', 'canvas', 'script', 'noscript', 'style', 'link', 'meta', 'title', 'base', 'head', 'body', 'html', 'br', 'hr', 'wbr', 'img', 'area', ]
 
-  
+  let uri = properties.uri;
 
   let type;
 
@@ -46,12 +46,7 @@ export default function Plugin(properties) {
       type = properties.type
   }
 
-  const pluginData = {
-    uriSuffix: properties.uri.split(theme.uriPrefix).join(''),
-    instanceUrl: `${publicRuntimeConfig.backend}/`,
-    size: 1,
-    type: type
-  };
+  
 
   useEffect(() => {
     if (status === null) {
@@ -60,6 +55,27 @@ export default function Plugin(properties) {
 
         if(responseStatus) {
           const downloadContent = async () => {
+            if(!uri.includes('/public/')) {
+              const shareLink = await getShareLink(uri.split(theme.uriPrefix).join(''));
+              uri = shareLink;
+              //Replace backend with uriPrefix
+              uri = uri.replace(publicRuntimeConfig.backend, theme.uriPrefix);
+            }
+
+            let uriSuffix = uri.split(theme.uriPrefix).join('');
+            //Remove first slash if it exists
+            if (uriSuffix.startsWith('/')) {
+              uriSuffix = uriSuffix.slice(1);
+            }
+
+            const pluginData = {
+              uriSuffix: uriSuffix,
+              instanceUrl: `${publicRuntimeConfig.backend}/`,
+              size: 1,
+              type: type,
+              top: properties.uri
+            };
+
             const renderResponse = await runPlugin(properties.plugin, pluginData, pluginsUseLocalCompose, pluginLocalComposePrefix);
             setContent(renderResponse.data);
             setStatus(renderResponse.status === 200);
@@ -170,6 +186,24 @@ async function evaluatePlugin(plugin, type, pluginsUseLocalCompose, pluginLocalC
   })
   .catch(error => {
     return false;
+  });
+}
+
+async function getShareLink(uriSuffix) {
+  const token = localStorage.getItem('userToken');
+  return await axios({
+    method: 'GET',
+    url: `${publicRuntimeConfig.backend}/${uriSuffix}/shareLink`,
+    user: token, // Assuming the API requires a user token for authentication
+    headers: {
+      'Accept': 'text/plain',
+      'X-authorization': token
+    }
+  }).then(response => {
+    return response.data;
+  }
+  ).catch(error => {
+    return error;
   });
 }
 


### PR DESCRIPTION
closes #858 

Can be tested using seqviz locally on SBH1 and SBH2 for private/public data, monitoring the terminal outputs from the plugin and ensuring their logs match (logs include printing the run urls and share links)